### PR TITLE
Add pre_build_script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cd zmake
 
 # Create and activate venv
 python3.10 -m venv venv
-source venv/bin/active
+source venv/bin/activate
 
 # Install deps and build
 pip install -r requirements.txt

--- a/zmake/project_build.py
+++ b/zmake/project_build.py
@@ -22,6 +22,14 @@ LIST_COMMON_FILES = [
 ]
 
 
+@build_handler("Pre-build command")
+def post_build(context: ZMakeContext):
+    if context.config.get("pre_build_script", "") == "":
+        return
+
+    subprocess.Popen([os.path.expanduser(context.config["pre_build_script"]), str(context.path)]).wait()
+
+
 @build_handler("Prepare")
 def prepare(context: ZMakeContext):
     path_build = context.path / "build"
@@ -385,4 +393,4 @@ def post_build(context: ZMakeContext):
     if context.config["post_build_script"] == "":
         return
 
-    subprocess.Popen([context.config["post_build_script"], str(context.path)]).wait()
+    subprocess.Popen([os.path.expanduser(context.config["post_build_script"]), str(context.path)]).wait()

--- a/zmake/zmake.json
+++ b/zmake/zmake.json
@@ -20,6 +20,7 @@
   "with_adb": false,
   "adb_path": "/storage/emulated/0/Android/data/com.xiaomi.hm.health/files/watch_skin_local",
 
+  "pre_build_script": "",
   "post_build_script": "",
 
   "common_files": [],


### PR DESCRIPTION
- Add `pre_build_script` support, similar to `post_build_script`.
  - For backwards compatibility with existing `zmake.json` files, `context.config.get("pre_build_script", "")` is called instead of `context.config["post_build_script"]` to avoid errors if `"pre_build_script"` is undefined.
- Expand both `pre_build_script` and `post_build_script` contents with `os.path.expanduser` to expand `~` into the user's home directory.
- Fix a typo in the README.