### PR TITLE
Use "common_files" config + add "ignore_files" config

### DIFF
--- a/zmake/project_build.py
+++ b/zmake/project_build.py
@@ -13,13 +13,13 @@ from zmake import utils, image_io, constants
 from zmake.context import build_handler, ZMakeContext
 from zmake.third_tools_manager import run_ext_tool
 
-LIST_COMMON_FILES = [
-    "README.txt",
-    "LICENSE.txt",
-    "README",
-    "LICENSE",
-    "secondary-widget"
-]
+
+def should_ignore_file(filename: str, context: ZMakeContext):
+    for file_to_ignore in context.config.get("ignore_files", [".DS_Store", "Thumbs.db"]):
+        if file_to_ignore in filename:
+            return True
+
+    return False
 
 
 @build_handler("Pre-build command")
@@ -138,7 +138,7 @@ def handle_assets(context: ZMakeContext):
 @build_handler("Common files")
 def common_files(context: ZMakeContext):
     context.logger.info("Copying common files:")
-    files = LIST_COMMON_FILES
+    files = context.config["common_files"]
     for fn in files:
         p = context.path / fn
         if p.is_dir():
@@ -317,7 +317,7 @@ def package(context: ZMakeContext):
     with ZipFile(device_zip, "w", ZIP_DEFLATED) as arc:
         for file in (context.path / "build").rglob("**/*"):
             fn = str(file)[len(str(context.path / "build")):]
-            if ".DS_Store" in fn or "Thumbs.db" in fn:
+            if should_ignore_file(fn, context):
                 context.logger.info(f"Skip: {fn}")
                 continue
             arc.write(file, fn)
@@ -349,7 +349,7 @@ def make_zeus_pkg(context: ZMakeContext):
     with ZipFile(device_zip_file, "w", ZIP_DEFLATED) as archive:
         for file in (context.path / "build").rglob("**/*"):
             fn = str(file)[len(str(context.path / "build")):]
-            if ".DS_Store" in fn or "Thumbs.db" in fn:
+            if should_ignore_file(fn, context):
                 continue
             archive.write(file, fn)
 

--- a/zmake/zmake.json
+++ b/zmake/zmake.json
@@ -23,7 +23,8 @@
   "pre_build_script": "",
   "post_build_script": "",
 
-  "common_files": [],
+  "common_files": ["README.txt", "LICENSE.txt", "README", "LICENSE", "secondary-widget"],
+  "ignore_files": [".gitignore", ".DS_Store", "Thumbs.db"],
 
   "with_zeus_compat": false,
   "zeus_target": "mi-band7",


### PR DESCRIPTION
- `zmake.json` already has a `"common_files"` config, but it has not been used. Instead, `project_build.py` has a hardcoded list of common files: `["README.txt", "LICENSE.txt", "README", "LICENSE", "secondary-widget"]` that is used in the `common_files` handler. This PR moves the hardcoded list into the `"common_files"` config and uses the latter in the `common_files` handler.
  - **Note: This is a breaking change** for anyone using an existing `zmake.json` since the previous default was `"common_files": []`. Feel free to suggest better ways to handle this for backwards compatibility.
- The `package` and `make_zeus_pkg` handlers already exclude `.DS_Store` and `Thumbs.db`, but the resulting packages do include `.gitignore` and potentially other files that should be ignored, like source maps (if `uglifyjs` is called with `--source-map`). This PR adds a `"ignore_files"` config to `zmake.json` and uses it in the `package` and `make_zeus_pkg` handlers.
  - **Notes:**
    - For backwards compatibility with existing `zmake.json` files, `"ignore_files"` defaults to `[".DS_Store", "Thumbs.db"]` if not present in `zmake.json`.
      - However, the default entry added to `zmake.json` also includes `".gitignore"` since I cannot think of any reason for that to exist in the built package. - The existing substring logic (`if ".DS_Store" in fn or "Thumbs.db" in fn`) is kept, just using the `"ignore_files"` config instead. Wildcards are not currently supported.